### PR TITLE
Add demo simulating a mail spam detection service

### DIFF
--- a/transpiler/README.md
+++ b/transpiler/README.md
@@ -327,6 +327,33 @@ and
 ```shell
 bazel run -c opt //transpiler/examples/templates:mul_interpreted_tfhe_testbench
 ```
+### Mail spam detection
+
+This demo simulates a service that checks if a mail is spam without the server
+seeing the mail or the result. If a mail contains "evil.url", it will be classified
+as spam.
+
+Reference: https://vitalik.ca/general/2020/07/20/homomorphic.html
+
+*  Baseline FHE-C++ translation command:
+   ```shell
+   bazel run //transpiler/examples/is_mail_spam:is_mail_spam_tfhe_testbench "click evil.url!"
+   ```
+*  Multi-core interpreter command:
+   ```shell
+   bazel run //transpiler/examples/is_mail_spam:is_mail_spam_interpreted_tfhe_testbench "click evil.url!"
+   ```
+
+Sample output:
+```
+[Client] Mail to be checked for spam: "click evil.url!"
+[Client] Mail encryption done
+
+                                                        [Server] Computing...
+                                                        [Server] Computation done
+[Client] Decrypted result: 1
+[Client] Mail is spam!
+```
 
 ## Design
 

--- a/transpiler/examples/is_mail_spam/BUILD
+++ b/transpiler/examples/is_mail_spam/BUILD
@@ -1,0 +1,79 @@
+load("//transpiler:fhe.bzl", "fhe_cc_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+licenses(["notice"])
+
+cc_library(
+    name = "is_mail_spam",
+    srcs = ["is_mail_spam.cc"],
+    hdrs = ["is_mail_spam.h"],
+)
+
+fhe_cc_library(
+    name = "is_mail_spam_tfhe",
+    src = "is_mail_spam.cc",
+    hdrs = ["is_mail_spam.h"],
+    num_opt_passes = 2,
+)
+
+fhe_cc_library(
+    name = "is_mail_spam_interpreted_tfhe",
+    src = "is_mail_spam.cc",
+    hdrs = ["is_mail_spam.h"],
+    num_opt_passes = 2,
+    transpiler_type = "interpreted_tfhe",
+)
+
+fhe_cc_library(
+    name = "is_mail_spam_bool",
+    src = "is_mail_spam.cc",
+    hdrs = ["is_mail_spam.h"],
+    num_opt_passes = 2,
+    transpiler_type = "bool",
+)
+
+cc_binary(
+    name = "is_mail_spam_tfhe_testbench",
+    srcs = ["is_mail_spam_tfhe_testbench.cc"],
+    deps = [
+        ":is_mail_spam_tfhe",
+        "//transpiler/data:fhe_data",
+        "@com_google_xls//xls/common/logging",
+        "@com_google_xls//xls/common/status:status_macros",
+        "@tfhe//:libtfhe",
+    ],
+)
+
+cc_binary(
+    name = "is_mail_spam_interpreted_tfhe_testbench",
+    srcs = ["is_mail_spam_tfhe_testbench.cc"],
+    copts = ["-DUSE_INTERPRETED_TFHE"],
+    deps = [
+        ":is_mail_spam_interpreted_tfhe",
+        "//transpiler/data:fhe_data",
+        "@com_google_xls//xls/common/logging",
+        "@com_google_xls//xls/common/status:status_macros",
+        "@tfhe//:libtfhe",
+    ],
+)
+
+cc_binary(
+    name = "is_mail_spam_bool_testbench",
+    srcs = ["is_mail_spam_bool_testbench.cc"],
+    deps = [
+        ":is_mail_spam_bool",
+        "//transpiler/data:boolean_data",
+        "@com_google_xls//xls/common/logging",
+        "@com_google_xls//xls/common/status:status_macros",
+    ],
+)
+
+cc_test(
+    name = "is_mail_spam_test",
+    srcs = ["is_mail_spam_test.cc"],
+    deps = [
+        ":is_mail_spam",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_xls//xls/common/status:matchers",
+    ],
+)

--- a/transpiler/examples/is_mail_spam/is_mail_spam.cc
+++ b/transpiler/examples/is_mail_spam/is_mail_spam.cc
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "is_mail_spam.h"
+
+static bool containsSpam(char mail[kMaxMailSize], unsigned offset) {
+  static constexpr auto kSpamSize = 8 + 1;
+  const char spam_str[kSpamSize] = "evil.url";
+  auto contains = true;
+
+  #pragma hls_unroll yes
+  for (auto i = 0u; i < kSpamSize - 1; ++i) {
+    if (offset + i >= kMaxMailSize - 1 || mail[offset + i] != spam_str[i]) {
+      contains = false;
+      break;
+    }
+  }
+  return contains;
+}
+
+#pragma hls_top
+int isMailSpam(char mail[kMaxMailSize]) {
+  auto contains = false;
+  #pragma hls_unroll yes
+  for (auto i = 0; i < kMaxMailSize; ++i) {
+    if (mail[i] != '\0') {
+      if (containsSpam(mail, i)) {
+        contains = true;
+        break;
+      }
+    }
+  }
+  return (contains ? 1 : 0);
+}

--- a/transpiler/examples/is_mail_spam/is_mail_spam.h
+++ b/transpiler/examples/is_mail_spam/is_mail_spam.h
@@ -1,0 +1,23 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Maximum mail size, including the null terminator.
+static constexpr auto kMaxMailSize = 16 + 1u;
+
+// Returns 0 if the given mail is not spam and any other
+// value if it is spam.
+// `mail` must be null-terminated.
+int isMailSpam(char mail[kMaxMailSize]);

--- a/transpiler/examples/is_mail_spam/is_mail_spam_bool_testbench.cc
+++ b/transpiler/examples/is_mail_spam/is_mail_spam_bool_testbench.cc
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+
+#include "transpiler/data/boolean_data.h"
+#include "transpiler/examples/is_mail_spam/is_mail_spam_bool.h"
+#include "xls/common/logging/logging.h"
+
+#include "is_mail_spam.h"
+
+using namespace std;
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    cerr << "Error: missing mail" << endl;
+    cerr << "Usage: is_mail_spam \"mail contents\"" << endl;
+    return -1;
+  }
+
+  // Create an input (the email) on the client side.
+  //
+  // Make sure that the string buffer we pass is exactly `kMaxMailSize` bytes
+  // long and the last character is always the null terminator. We need the
+  // resize() and explicitly setting the last character to '\0' as EncodedString
+  // consumes as many bytes as in the std::string, but without its internal null
+  // terminator and we want to pass the terminator too to isMailSpam().
+  auto mail = string{argv[1]};
+  mail.resize(kMaxMailSize, '\0');
+  mail[kMaxMailSize - 1] = '\0';
+
+  // Encode the mail on the client side.
+  auto encoded_email = EncodedString{mail};
+  cout << "[Client] Mail to be checked for spam: \"" << mail << "\"" << endl;
+  cout << "[Client] Mail encoding done" << endl << endl;
+
+  // Perform mail spam detection on the server side.
+  cout << "\t\t\t\t\t\t\t[Server] Computing..." << endl;
+  auto encoded_result = EncodedInt{};
+  XLS_CHECK_OK(isMailSpam(encoded_result.get(), encoded_email.get()));
+  cout << "\t\t\t\t\t\t\t[Server] Computation done" << endl;
+
+  // Decode the result on the client side.
+  const auto is_spam = encoded_result.Decode();
+  cout << "[Client] Decoded result: " << is_spam << endl;
+  if (is_spam) {
+    cout << "[Client] Mail is spam!" << endl;
+  } else {
+    cout << "[Client] Mail is not spam." << endl;
+  }
+}

--- a/transpiler/examples/is_mail_spam/is_mail_spam_test.cc
+++ b/transpiler/examples/is_mail_spam/is_mail_spam_test.cc
@@ -1,0 +1,84 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "is_mail_spam.h"
+
+#include "gtest/gtest.h"
+
+#include <cstring>
+#include <string>
+
+class is_mail_spam : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mail_[0] = '\0';
+  }
+
+  void setMail(const std::string &mail) {
+    ASSERT_LT(mail.size(), kMaxMailSize);
+    std::memcpy(mail_, mail.data(), mail.size());
+    mail_[mail.size()] = '\0';
+  }
+
+  bool isMailSpam() {
+    const auto res = ::isMailSpam(mail_);
+    if (res) {
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  char mail_[kMaxMailSize] = {'\0',};
+};
+
+TEST_F(is_mail_spam, exact_match) {
+  setMail("evil.url");
+  ASSERT_TRUE(isMailSpam());
+}
+
+TEST_F(is_mail_spam, longer_contains_spam) {
+  setMail("click evil.url!");
+  ASSERT_TRUE(isMailSpam());
+}
+
+TEST_F(is_mail_spam, same_size_but_different_last_char) {
+  setMail("evil.ura");
+  ASSERT_FALSE(isMailSpam());
+}
+
+TEST_F(is_mail_spam, same_size_but_different_first_char) {
+  setMail("Bvil.url");
+  ASSERT_FALSE(isMailSpam());
+}
+
+TEST_F(is_mail_spam, same_size_but_different_char_in_the_middle) {
+  setMail("evil.crl");
+  ASSERT_FALSE(isMailSpam());
+}
+
+TEST_F(is_mail_spam, shorter_mail_than_spam) {
+  setMail("evil.ur");
+  ASSERT_FALSE(isMailSpam());
+}
+
+TEST_F(is_mail_spam, shorter_mail_than_spam_with_diff_char) {
+  setMail("evil-ur");
+  ASSERT_FALSE(isMailSpam());
+}
+
+TEST_F(is_mail_spam, longer_mail_does_not_contain_spam) {
+  setMail("dvil.urlx");
+  ASSERT_FALSE(isMailSpam());
+}

--- a/transpiler/examples/is_mail_spam/is_mail_spam_tfhe_testbench.cc
+++ b/transpiler/examples/is_mail_spam/is_mail_spam_tfhe_testbench.cc
@@ -1,0 +1,83 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+
+#include <iostream>
+#include <string>
+
+#include "tfhe/tfhe.h"
+#include "transpiler/data/fhe_data.h"
+#include "xls/common/logging/logging.h"
+
+#ifdef USE_INTERPRETED_TFHE
+#include "transpiler/examples/is_mail_spam/is_mail_spam_interpreted_tfhe.h"
+#else
+#include "transpiler/examples/is_mail_spam/is_mail_spam_tfhe.h"
+#endif
+
+#include "is_mail_spam.h"
+
+static const auto main_minimum_lambda = 120;
+
+using namespace std;
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    cerr << "Error: missing mail" << endl;
+    cerr << "Usage: is_mail_spam \"mail contents\"" << endl;
+    return -1;
+  }
+
+  // Generate a keyset.
+  auto params = new_default_gate_bootstrapping_parameters(main_minimum_lambda);
+
+  // Generate a random key.
+  // Note: In real applications, a cryptographically secure seed needs to be used.
+  uint32_t seed[] = {314, 1592, 657};
+  tfhe_random_generator_setSeed(seed, 3);
+  const auto key = new_random_gate_bootstrapping_secret_keyset(params);
+  const auto cloud_key = &key->cloud;
+
+  // Create an input (the email) on the client side.
+  //
+  // Make sure that the string buffer we pass is exactly `kMaxMailSize` bytes
+  // long and the last character is always the null terminator. We need the
+  // resize() and explicitly setting the last character to '\0' as FheString::Encrypt()
+  // consumes as many bytes as in the std::string, but without its internal null
+  // terminator and we want to pass the terminator too to isMailSpam().
+  auto mail = string{argv[1]};
+  mail.resize(kMaxMailSize, '\0');
+  mail[kMaxMailSize - 1] = '\0';
+
+  // Encrypt the mail on the client side.
+  auto mail_ciphertext = FheString::Encrypt(mail, key);
+  cout << "[Client] Mail to be checked for spam: \"" << mail << "\"" << endl;
+  cout << "[Client] Mail encryption done" << endl << endl;
+
+  // Perform mail spam detection on the server side.
+  cout << "\t\t\t\t\t\t\t[Server] Computing..." << endl;
+  auto cipher_result = FheInt{params};
+  XLS_CHECK_OK(isMailSpam(cipher_result.get(), mail_ciphertext.get(), cloud_key));
+  cout << "\t\t\t\t\t\t\t[Server] Computation done" << endl;
+
+  // Decrypt the result on the client side.
+  const auto is_spam = cipher_result.Decrypt(key);
+  cout << "[Client] Decrypted result: " << is_spam << endl;
+  if (is_spam) {
+    cout << "[Client] Mail is spam!" << endl;
+  } else {
+    cout << "[Client] Mail is not spam." << endl;
+  }
+}


### PR DESCRIPTION
This demo simulates a service that checks if a mail is spam without the
server seeing the mail or the result. If a mail contains "evil.url", it
will be classified as spam.

Add test benches, an unit test and update the README.

Reference: https://vitalik.ca/general/2020/07/20/homomorphic.html